### PR TITLE
Update UI highlight color to #00FF9D

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -208,7 +208,7 @@ export default function AccountPage() {
                   <Shield className="h-4 w-4 text-muted-foreground" />
                   <span className="text-muted-foreground">Account Status</span>
                 </div>
-                <p className="text-sm font-medium text-green-500">Active</p>
+                <p className="text-sm font-medium text-[#00FF9D]">Active</p>
               </div>
             </CardContent>
           </Card>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -85,7 +85,7 @@ export default function DashboardPage() {
   const getStatusColor = (status: string) => {
     switch (status) {
       case "completed":
-        return "bg-green-500/10 text-green-500 border-green-500/20"
+        return "bg-[#00FF9D]/10 text-[#00FF9D] border-[#00FF9D]/20"
       case "in-progress":
         return "bg-blue-500/10 text-blue-500 border-blue-500/20"
       case "pending":

--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -360,7 +360,7 @@ export default function DownloadPage() {
                   </div>
                   <div className="flex items-center gap-2">
                     {vendor && (
-                      <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/20">
+                      <Badge variant="outline" className="bg-[#00FF9D]/10 text-[#00FF9D] border-[#00FF9D]/20">
                         {vendor.name} • {vendor.price}
                       </Badge>
                     )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,8 +10,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: #00FF9D;
+  --primary-foreground: #032B1A;
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -31,8 +31,8 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: #00FF9D;
+  --sidebar-primary-foreground: #032B1A;
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
@@ -46,8 +46,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.145 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: #00FF9D;
+  --primary-foreground: #032B1A;
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -66,8 +66,8 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: #00FF9D;
+  --sidebar-primary-foreground: #032B1A;
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
@@ -125,7 +125,7 @@
 
 /* Custom gradient background pattern */
 .gradient-bg {
-  background: radial-gradient(circle at 20% 80%, rgba(34, 197, 94, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(34, 197, 94, 0.05) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(34, 197, 94, 0.03) 0%, transparent 50%);
+  background: radial-gradient(circle at 20% 80%, rgba(0, 255, 157, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(0, 255, 157, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(0, 255, 157, 0.03) 0%, transparent 50%);
 }

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -288,7 +288,7 @@ export default function ImportPage() {
                 </div>
                 <Progress value={importProgress.progress} className="h-2" />
                 {importProgress.step === "complete" && (
-                  <div className="flex items-center gap-2 text-green-600">
+                  <div className="flex items-center gap-2 text-[#00FF9D]">
                     <CheckCircle className="h-4 w-4" />
                     <span className="text-sm font-medium">Redirecting to review...</span>
                   </div>

--- a/app/purchase/page.tsx
+++ b/app/purchase/page.tsx
@@ -219,7 +219,7 @@ export default function PurchasePage() {
             </div>
             <Progress value={purchaseProgress.progress} className="h-2" />
             {purchaseProgress.step === "complete" && (
-              <div className="flex items-center gap-2 text-green-600">
+              <div className="flex items-center gap-2 text-[#00FF9D]">
                 <CheckCircle className="h-4 w-4" />
                 <span className="text-sm font-medium">All purchase links ready!</span>
               </div>
@@ -245,7 +245,7 @@ export default function PurchasePage() {
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
                       <h3 className="font-medium">{track.name}</h3>
-                      {isCompleted && <CheckCircle className="h-4 w-4 text-green-600" />}
+                      {isCompleted && <CheckCircle className="h-4 w-4 text-[#00FF9D]" />}
                     </div>
                     <p className="text-sm text-muted-foreground">
                       {track.artist} • {track.album}
@@ -253,7 +253,7 @@ export default function PurchasePage() {
                   </div>
                   <div className="flex items-center gap-3">
                     {bestVendor && (
-                      <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/20">
+                      <Badge variant="outline" className="bg-[#00FF9D]/10 text-[#00FF9D] border-[#00FF9D]/20">
                         {bestVendor.name} • {bestVendor.price}
                       </Badge>
                     )}
@@ -291,7 +291,7 @@ export default function PurchasePage() {
             onClick={handleStartPurchase}
             disabled={isPurchasing}
             size="lg"
-            className="bg-green-600 hover:bg-green-700"
+            className="bg-[#00FF9D] hover:bg-[#00E38C] text-[#032B1A]"
           >
             {isPurchasing ? (
               <>

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -259,7 +259,7 @@ const formattedTotalCost = formatCurrency(totalCost)
             <Button
               onClick={handleBulkPurchase}
               disabled={selectedTracks.size === 0 || isProcessingPurchase}
-              className="bg-green-600 hover:bg-green-700"
+              className="bg-[#00FF9D] hover:bg-[#00E38C] text-[#032B1A]"
             >
               {isProcessingPurchase ? (
                 <>


### PR DESCRIPTION
## Summary
- update the global primary color tokens and landing gradient to use the new #00FF9D accent
- refresh badges, status indicators, and action buttons across dashboard, review, purchase, download, and account views to match the new highlight tone

## Testing
- Not run (Next.js lint command prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_b_68d6dffa02f48322b9d8b1e52b12d096