### PR TITLE
Add confirm password validation to signup form

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -15,11 +15,20 @@ export default function SignupPage() {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError(null)
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match")
+      return
+    }
+
     setIsLoading(true)
 
     // Simulate API call
@@ -98,6 +107,18 @@ export default function SignupPage() {
                   required
                 />
               </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirm-password">Confirm Password</Label>
+                <Input
+                  id="confirm-password"
+                  type="password"
+                  placeholder="Re-enter your password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                />
+              </div>
+              {error && <p className="text-sm text-destructive">{error}</p>}
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? "Creating account..." : "Create Account"}
               </Button>


### PR DESCRIPTION
## Summary
- add a confirm password field to the signup form
- block submission when the password confirmation does not match and show an inline error

## Testing
- yarn lint *(fails: command prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_68d6ec42ff048322ad2e5993bff73b5a